### PR TITLE
Update to OWLAPI 4.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 *.idea
 .DS_Store
 *.class
-*.class
-target/
+target
+.project
+.classpath
+.settings

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>skos-api</artifactId>
         <groupId>skos-api</groupId>
-        <version>3.1</version>
+        <version>3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                  <source>1.6</source>
-                  <target>1.6</target>
+                  <source>1.7</source>
+                  <target>1.7</target>
                 </configuration>
               </plugin>
         </plugins>
@@ -34,7 +34,7 @@
     <groupId>skos-api</groupId>
     <artifactId>skos-api</artifactId>
     <packaging>pom</packaging>
-    <version>3.1</version>
+    <version>3.2-SNAPSHOT</version>
     <modules>
         <module>skos-core</module>
         <module>skos-impl</module>

--- a/skos-core/pom.xml
+++ b/skos-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>skos-api</artifactId>
         <groupId>skos-api</groupId>
-        <version>3.1</version>
+        <version>3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/skos-example/pom.xml
+++ b/skos-example/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>skos-api</artifactId>
         <groupId>skos-api</groupId>
-        <version>3.1</version>
+        <version>3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>skos-api</groupId>
             <artifactId>skos-impl</artifactId>
-            <version>3.1</version>
+            <version>3.2-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/skos-example/src/main/java/example/CreateSKOSExample.java
+++ b/skos-example/src/main/java/example/CreateSKOSExample.java
@@ -1,13 +1,5 @@
 package example;
 
-import org.semanticweb.owlapi.model.*;
-import org.semanticweb.owlapi.vocab.DublinCoreVocabulary;
-import org.semanticweb.skos.*;
-import org.semanticweb.skos.properties.SKOSAltLabelProperty;
-import org.semanticweb.skosapibinding.SKOSFormatExt;
-import org.semanticweb.skosapibinding.SKOSManager;
-import org.semanticweb.skosapibinding.SKOStoOWLConverter;
-
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,6 +25,38 @@ import java.util.List;
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
+
+import org.semanticweb.owlapi.model.AddAxiom;
+import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.semanticweb.owlapi.model.OWLOntologyChangeException;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.model.OWLSubAnnotationPropertyOfAxiom;
+import org.semanticweb.owlapi.vocab.DublinCoreVocabulary;
+import org.semanticweb.skos.AddAssertion;
+import org.semanticweb.skos.SKOSAnnotation;
+import org.semanticweb.skos.SKOSAnnotationAssertion;
+import org.semanticweb.skos.SKOSAnnotationProperty;
+import org.semanticweb.skos.SKOSChange;
+import org.semanticweb.skos.SKOSChangeException;
+import org.semanticweb.skos.SKOSConcept;
+import org.semanticweb.skos.SKOSConceptScheme;
+import org.semanticweb.skos.SKOSCreationException;
+import org.semanticweb.skos.SKOSDataFactory;
+import org.semanticweb.skos.SKOSDataRelationAssertion;
+import org.semanticweb.skos.SKOSDataset;
+import org.semanticweb.skos.SKOSEntity;
+import org.semanticweb.skos.SKOSEntityAssertion;
+import org.semanticweb.skos.SKOSLiteral;
+import org.semanticweb.skos.SKOSObject;
+import org.semanticweb.skos.SKOSObjectRelationAssertion;
+import org.semanticweb.skos.SKOSResource;
+import org.semanticweb.skos.SKOSStorageException;
+import org.semanticweb.skos.SKOSTypedLiteral;
+import org.semanticweb.skos.SKOSUntypedLiteral;
+import org.semanticweb.skos.properties.SKOSAltLabelProperty;
+import org.semanticweb.skosapibinding.SKOSFormatExt;
+import org.semanticweb.skosapibinding.SKOSManager;
+import org.semanticweb.skosapibinding.SKOStoOWLConverter;
 
 /**
  * Author: Simon Jupp<br>
@@ -122,10 +146,10 @@ public class CreateSKOSExample {
         * here is an example adding a dc:creator and a rdfs:comment
         */
 
-        SKOSAnnotation anno1 = factory.getSKOSAnnotation(DublinCoreVocabulary.DATE.getURI(), "12-07-2008");
-        SKOSAnnotation anno2 = factory.getSKOSAnnotation(DublinCoreVocabulary.CREATOR.getURI(), "Simon Jupp", "en");
+        SKOSAnnotation anno1 = factory.getSKOSAnnotation(DublinCoreVocabulary.DATE.getIRI().toURI(), "12-07-2008");
+        SKOSAnnotation anno2 = factory.getSKOSAnnotation(DublinCoreVocabulary.CREATOR.getIRI().toURI(), "Simon Jupp", "en");
         SKOSAnnotation anno3 = factory.getSKOSAnnotation(URI.create("http://my-custom-annotation.com/example"), someResource);
-        SKOSAnnotation anno4 = factory.getSKOSAnnotation(DublinCoreVocabulary.CREATOR.getURI(),  factory.getSKOSUntypedConstant("Simon Jupp", "en"));
+        SKOSAnnotation anno4 = factory.getSKOSAnnotation(DublinCoreVocabulary.CREATOR.getIRI().toURI(),  factory.getSKOSUntypedConstant("Simon Jupp", "en"));
         // todo need to work on typed on objects
         //factory.getSKOSAnnotationsByURI(DublinCoreVocabulary.CREATOR.getURI(),  factory.getSKOSTypedConstant("String", "Simon Jupp"));
 

--- a/skos-example/src/main/java/example/Example4.java
+++ b/skos-example/src/main/java/example/Example4.java
@@ -1,15 +1,5 @@
 package example;
 
-import org.semanticweb.owlapi.model.OWLObjectProperty;
-import org.semanticweb.owlapi.model.OWLObjectPropertyExpression;
-import org.semanticweb.owlapi.model.OWLOntology;
-import org.semanticweb.skos.SKOSCreationException;
-import org.semanticweb.skos.SKOSDataFactory;
-import org.semanticweb.skos.SKOSDataset;
-import org.semanticweb.skos.SKOSObjectProperty;
-import org.semanticweb.skosapibinding.SKOSManager;
-import org.semanticweb.skosapibinding.SKOStoOWLConverter;
-
 import java.net.URI;
 /*
  * Copyright (C) 2007, University of Manchester
@@ -33,6 +23,17 @@ import java.net.URI;
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
+
+import org.semanticweb.owlapi.model.OWLObjectProperty;
+import org.semanticweb.owlapi.model.OWLObjectPropertyExpression;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.search.EntitySearcher;
+import org.semanticweb.skos.SKOSCreationException;
+import org.semanticweb.skos.SKOSDataFactory;
+import org.semanticweb.skos.SKOSDataset;
+import org.semanticweb.skos.SKOSObjectProperty;
+import org.semanticweb.skosapibinding.SKOSManager;
+import org.semanticweb.skosapibinding.SKOStoOWLConverter;
 
 /**
  * Author: Simon Jupp<br>
@@ -59,7 +60,7 @@ public class Example4 {
             // get the SKOS dataset as an owl ontology object
             OWLOntology onto = conv.getAsOWLOntology(dataset);
             //query the owl ontology for superproperties
-            for (OWLObjectPropertyExpression prop : owlPartOf.getSuperProperties(onto)) {
+            for (OWLObjectPropertyExpression prop : EntitySearcher.getSuperProperties(owlPartOf, onto)) {
                 System.out.println(prop.asOWLObjectProperty().getIRI());
             }
 

--- a/skos-example/src/main/java/example/ReadInferredSKOS.java
+++ b/skos-example/src/main/java/example/ReadInferredSKOS.java
@@ -1,16 +1,5 @@
 package example;
 
-import org.semanticweb.owlapi.apibinding.OWLManager;
-import org.semanticweb.owlapi.model.*;
-import org.semanticweb.owlapi.reasoner.BufferingMode;
-import org.semanticweb.owlapi.reasoner.OWLReasoner;
-import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
-import org.semanticweb.skos.*;
-import org.semanticweb.skosapibinding.SKOSFormatExt;
-import org.semanticweb.skosapibinding.SKOSManager;
-import org.semanticweb.skosapibinding.SKOSReasoner;
-import org.semanticweb.skosapibinding.SKOStoOWLConverter;
-
 import java.net.URI;
 /*
  * Copyright (C) 2007, University of Manchester
@@ -34,6 +23,16 @@ import java.net.URI;
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
+
+import org.semanticweb.owlapi.model.AddImport;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLImportsDeclaration;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.parameters.ChangeApplied;
+import org.semanticweb.skos.SKOSCreationException;
+import org.semanticweb.skos.SKOSDataset;
+import org.semanticweb.skosapibinding.SKOSManager;
+import org.semanticweb.skosapibinding.SKOStoOWLConverter;
 
 /**
  * Author: Simon Jupp<br>
@@ -95,8 +94,9 @@ public class ReadInferredSKOS {
 
             OWLImportsDeclaration importsDec = manager.getOWLManger().getOWLDataFactory().getOWLImportsDeclaration(IRI.create ("http://www.w3.org/2004/02/skos/core"));
 
-            for (OWLOntologyChange change: manager.getOWLManger().applyChange(new AddImport(mySkosAsOWLOntology, importsDec))) {
-                System.out.println(change.toString());
+            AddImport addImport = new AddImport(mySkosAsOWLOntology, importsDec);
+            if( manager.getOWLManger().applyChange(addImport)==ChangeApplied.SUCCESSFULLY) {
+                System.out.println(addImport.toString());
             }
 
 //            SKOSDataset skosCoreOntology = manager.loadDataset(URI.create("http://www.w3.org/2004/02/skos/core"));

--- a/skos-impl/pom.xml
+++ b/skos-impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>skos-api</artifactId>
         <groupId>skos-api</groupId>
-        <version>3.1</version>
+        <version>3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -16,13 +16,13 @@
         <dependency>
             <groupId>skos-api</groupId>
             <artifactId>skos-core</artifactId>
-            <version>3.1</version>
+            <version>3.2-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>net.sourceforge.owlapi</groupId>
-            <artifactId>owlapi-distribution</artifactId>
-            <version>3.4.10</version>
+            <artifactId>owlapi-osgidistribution</artifactId>
+            <version>[4.0.2,4.1)</version>
         </dependency>
 
     </dependencies>

--- a/skos-impl/src/main/java/org/semanticweb/skosapibinding/SKOSFormatExt.java
+++ b/skos-impl/src/main/java/org/semanticweb/skosapibinding/SKOSFormatExt.java
@@ -1,10 +1,11 @@
 package org.semanticweb.skosapibinding;
 
-import org.coode.owlapi.manchesterowlsyntax.ManchesterOWLSyntaxOntologyFormat;
-import org.coode.owlapi.turtle.TurtleOntologyFormat;
-import org.semanticweb.owlapi.io.OWLXMLOntologyFormat;
-import org.semanticweb.owlapi.io.RDFXMLOntologyFormat;
-import org.semanticweb.owlapi.model.OWLOntologyFormat;
+import org.semanticweb.owlapi.formats.ManchesterSyntaxDocumentFormatFactory;
+import org.semanticweb.owlapi.formats.OWLXMLDocumentFormatFactory;
+import org.semanticweb.owlapi.formats.RDFXMLDocumentFormatFactory;
+import org.semanticweb.owlapi.formats.TurtleDocumentFormatFactory;
+import org.semanticweb.owlapi.model.OWLDocumentFormat;
+import org.semanticweb.owlapi.model.OWLDocumentFormatFactory;
 import org.semanticweb.skos.SKOSFormat;
 import org.semanticweb.skos.SKOSUnkownFormatException;
 
@@ -41,37 +42,23 @@ public enum SKOSFormatExt implements SKOSFormat {
 
 //    RDFXML(new OWLXMLVocabulary());
 
-    RDFXML("RDFXML") ,
+    RDFXML(new RDFXMLDocumentFormatFactory()) ,
 
-    TURTRLE("TURTLE"),
+    TURTRLE(new TurtleDocumentFormatFactory()),
 
-    OWLXML("OWLXML"),
+    OWLXML(new OWLXMLDocumentFormatFactory()),
 
-    MOS("MOS");
+    MOS(new ManchesterSyntaxDocumentFormatFactory());
 
-    private String localName;
+    private OWLDocumentFormatFactory factory;
 
 
-    SKOSFormatExt(String localname) {
-        this.localName = localname;
+    SKOSFormatExt(OWLDocumentFormatFactory factory) {
+        this.factory=factory;
     }
 
 
-    public OWLOntologyFormat getFormat() throws SKOSUnkownFormatException {
-
-        if (localName.equals("RDFXML")) {
-            return new RDFXMLOntologyFormat();
-        }
-        else if (localName.equals("OWLXML")) {
-            return new OWLXMLOntologyFormat();
-        }
-        else if (localName.equals("MOS")) {
-            return new ManchesterOWLSyntaxOntologyFormat();
-        }
-        else if (localName.equals("TURTLE")) {
-            return new TurtleOntologyFormat();
-        }
-
-        throw new SKOSUnkownFormatException("Unknown format: " + localName);
+    public OWLDocumentFormat getFormat() throws SKOSUnkownFormatException {
+        return factory.createFormat();
     }
 }

--- a/skos-impl/src/main/java/uk/ac/manchester/cs/skos/SKOSObjectPropertyUtility.java
+++ b/skos-impl/src/main/java/uk/ac/manchester/cs/skos/SKOSObjectPropertyUtility.java
@@ -1,8 +1,7 @@
 package uk.ac.manchester.cs.skos;
 
-import org.semanticweb.owlapi.model.*;
-
 import java.net.URI;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 /*
@@ -27,6 +26,13 @@ import java.util.Map;
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
+
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLObjectProperty;
+import org.semanticweb.owlapi.model.OWLObjectPropertyExpression;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.search.EntitySearcher;
 
 /**
  * Author: Simon Jupp<br>
@@ -69,9 +75,10 @@ public class SKOSObjectPropertyUtility {
 
     private void processProperty(OWLObjectProperty prop, OWLOntology ont) {
 
-        if (!prop.getSuperProperties(ont).isEmpty()) {
+        Collection<OWLObjectPropertyExpression> superProperties = EntitySearcher.getSuperProperties(prop, ont);
+        if (!superProperties.isEmpty()) {
             tempProperty.put(prop.getIRI().toURI(), prop);
-            for(OWLObjectPropertyExpression sup : prop.getSuperProperties(ont)) {
+            for(OWLObjectPropertyExpression sup : superProperties) {
                 processProperty(sup.asOWLObjectProperty(), ont);
             }
         }

--- a/skos-impl/src/main/java/uk/ac/manchester/cs/skos/SKOSTypedLiteralImpl.java
+++ b/skos-impl/src/main/java/uk/ac/manchester/cs/skos/SKOSTypedLiteralImpl.java
@@ -45,7 +45,7 @@ public class SKOSTypedLiteralImpl implements SKOSTypedLiteral {
     public SKOSTypedLiteralImpl(OWLDataFactory factory, SKOSDataType dataType, String literal) {
         this.literal = literal;
         this.type = (SKOSDataTypeImpl) dataType;
-        constant = factory.getOWLTypedLiteral(literal, type.getAsOWLDataType());
+        constant = factory.getOWLLiteral(literal, type.getAsOWLDataType());
     }
 
     public String getLiteral() {


### PR DESCRIPTION
This patch updates the SKOS api to OWLAPI 4.0.2
OWLAPI 4.0.2 has not been released yet - this is to test that Protege works well with it :-)