### PR TITLE
Update to use v4.2.8 of the OWL API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 *.class
 *.class
 target/
+.project
+.classpath
+*.core.prefs
+.jazzignore

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>skos-api</artifactId>
         <groupId>skos-api</groupId>
-        <version>3.1</version>
+        <version>3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <groupId>skos-api</groupId>
     <artifactId>skos-api</artifactId>
     <packaging>pom</packaging>
-    <version>3.1</version>
+    <version>3.2</version>
     <modules>
         <module>skos-core</module>
         <module>skos-impl</module>

--- a/skos-core/pom.xml
+++ b/skos-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>skos-api</artifactId>
         <groupId>skos-api</groupId>
-        <version>3.1</version>
+        <version>3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/skos-example/pom.xml
+++ b/skos-example/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>skos-api</artifactId>
         <groupId>skos-api</groupId>
-        <version>3.1</version>
+        <version>3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>skos-api</groupId>
             <artifactId>skos-impl</artifactId>
-            <version>3.1</version>
+            <version>3.2</version>
         </dependency>
     </dependencies>
 

--- a/skos-example/src/main/java/example/CreateSKOSExample.java
+++ b/skos-example/src/main/java/example/CreateSKOSExample.java
@@ -122,10 +122,10 @@ public class CreateSKOSExample {
         * here is an example adding a dc:creator and a rdfs:comment
         */
 
-        SKOSAnnotation anno1 = factory.getSKOSAnnotation(DublinCoreVocabulary.DATE.getURI(), "12-07-2008");
-        SKOSAnnotation anno2 = factory.getSKOSAnnotation(DublinCoreVocabulary.CREATOR.getURI(), "Simon Jupp", "en");
+        SKOSAnnotation anno1 = factory.getSKOSAnnotation(DublinCoreVocabulary.DATE.getIRI().toURI(), "12-07-2008");
+        SKOSAnnotation anno2 = factory.getSKOSAnnotation(DublinCoreVocabulary.CREATOR.getIRI().toURI(), "Simon Jupp", "en");
         SKOSAnnotation anno3 = factory.getSKOSAnnotation(URI.create("http://my-custom-annotation.com/example"), someResource);
-        SKOSAnnotation anno4 = factory.getSKOSAnnotation(DublinCoreVocabulary.CREATOR.getURI(),  factory.getSKOSUntypedConstant("Simon Jupp", "en"));
+        SKOSAnnotation anno4 = factory.getSKOSAnnotation(DublinCoreVocabulary.CREATOR.getIRI().toURI(),  factory.getSKOSUntypedConstant("Simon Jupp", "en"));
         // todo need to work on typed on objects
         //factory.getSKOSAnnotationsByURI(DublinCoreVocabulary.CREATOR.getURI(),  factory.getSKOSTypedConstant("String", "Simon Jupp"));
 

--- a/skos-example/src/main/java/example/Example4.java
+++ b/skos-example/src/main/java/example/Example4.java
@@ -3,6 +3,7 @@ package example;
 import org.semanticweb.owlapi.model.OWLObjectProperty;
 import org.semanticweb.owlapi.model.OWLObjectPropertyExpression;
 import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.search.EntitySearcher;
 import org.semanticweb.skos.SKOSCreationException;
 import org.semanticweb.skos.SKOSDataFactory;
 import org.semanticweb.skos.SKOSDataset;
@@ -59,7 +60,7 @@ public class Example4 {
             // get the SKOS dataset as an owl ontology object
             OWLOntology onto = conv.getAsOWLOntology(dataset);
             //query the owl ontology for superproperties
-            for (OWLObjectPropertyExpression prop : owlPartOf.getSuperProperties(onto)) {
+            for (OWLObjectPropertyExpression prop : EntitySearcher.getSuperProperties(owlPartOf, onto)) {
                 System.out.println(prop.asOWLObjectProperty().getIRI());
             }
 

--- a/skos-example/src/main/java/example/ReadInferredSKOS.java
+++ b/skos-example/src/main/java/example/ReadInferredSKOS.java
@@ -2,6 +2,7 @@ package example;
 
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.*;
+import org.semanticweb.owlapi.model.parameters.ChangeApplied;
 import org.semanticweb.owlapi.reasoner.BufferingMode;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
 import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
@@ -95,8 +96,9 @@ public class ReadInferredSKOS {
 
             OWLImportsDeclaration importsDec = manager.getOWLManger().getOWLDataFactory().getOWLImportsDeclaration(IRI.create ("http://www.w3.org/2004/02/skos/core"));
 
-            for (OWLOntologyChange change: manager.getOWLManger().applyChange(new AddImport(mySkosAsOWLOntology, importsDec))) {
-                System.out.println(change.toString());
+            ChangeApplied change = manager.getOWLManger().applyChange(new AddImport(mySkosAsOWLOntology, importsDec));
+            if (null != change) {
+            	System.out.println(change.toString());
             }
 
 //            SKOSDataset skosCoreOntology = manager.loadDataset(URI.create("http://www.w3.org/2004/02/skos/core"));

--- a/skos-impl/pom.xml
+++ b/skos-impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>skos-api</artifactId>
         <groupId>skos-api</groupId>
-        <version>3.1</version>
+        <version>3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -16,13 +16,19 @@
         <dependency>
             <groupId>skos-api</groupId>
             <artifactId>skos-core</artifactId>
-            <version>3.1</version>
+            <version>3.2</version>
         </dependency>
 
         <dependency>
             <groupId>net.sourceforge.owlapi</groupId>
-            <artifactId>owlapi-distribution</artifactId>
-            <version>3.4.10</version>
+            <artifactId>owlapi-osgidistribution</artifactId>
+            <version>4.2.8</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
         </dependency>
 
     </dependencies>

--- a/skos-impl/src/main/java/org/semanticweb/skosapibinding/SKOSManager.java
+++ b/skos-impl/src/main/java/org/semanticweb/skosapibinding/SKOSManager.java
@@ -1,8 +1,11 @@
 package org.semanticweb.skosapibinding;
 
+import com.google.common.base.Optional;
+
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.io.RDFXMLOntologyFormat;
 import org.semanticweb.owlapi.model.*;
+import org.semanticweb.owlapi.model.parameters.ChangeApplied;
 import org.semanticweb.owlapi.util.BidirectionalShortFormProviderAdapter;
 import org.semanticweb.skos.*;
 import uk.ac.manchester.cs.skos.SKOSDataFactoryImpl;
@@ -68,7 +71,7 @@ public class SKOSManager implements SKOSContentManager {
         skosVocabularies = new HashMap<URI, SKOSDatasetImpl>();
 
         for (OWLOntology ont : man.getOntologies()) {
-            IRI iri = ont.getOntologyID().getOntologyIRI();
+            IRI iri = ont.getOntologyID().getOntologyIRI().get();
             if (iri == null) {
                 iri = IRI.generateDocumentIRI();
             }
@@ -221,17 +224,16 @@ public class SKOSManager implements SKOSContentManager {
 
         List<SKOSChange> succesfulChanges = new ArrayList<SKOSChange>();
 
-        List<OWLOntologyChange> OWLChange;// = new ArrayList<OWLOntologyChange>();
+        ChangeApplied OWLChange = null;
+        
         try {
             OWLChange = man.applyChanges(ch);
         } catch (OWLOntologyChangeException e) {
             throw new SKOSChangeException(newChanges.get(e.getChange()), e);
         }
 
-        for (OWLOntologyChange ch1 : OWLChange) {
-            if (newChanges.containsKey(ch1)) {
-                succesfulChanges.add(newChanges.get(ch1));
-            }
+        if (null != OWLChange && OWLChange.equals(ChangeApplied.SUCCESSFULLY)) {
+            succesfulChanges.addAll(newChanges.values());
         }
         return succesfulChanges;
     }
@@ -245,7 +247,8 @@ public class SKOSManager implements SKOSContentManager {
 
         List<SKOSChange> succesfulChanges = new ArrayList<SKOSChange>();
 
-        List<OWLOntologyChange> OWLChange = new ArrayList<OWLOntologyChange>();
+        ChangeApplied OWLChange = null;
+        
         try {
             OWLAxiomChange cha;
             if (change.isAdd()) {

--- a/skos-impl/src/main/java/uk/ac/manchester/cs/skos/SKOSDatasetImpl.java
+++ b/skos-impl/src/main/java/uk/ac/manchester/cs/skos/SKOSDatasetImpl.java
@@ -1,6 +1,7 @@
 package uk.ac.manchester.cs.skos;
 
 import org.semanticweb.owlapi.model.*;
+import org.semanticweb.owlapi.search.EntitySearcher;
 import org.semanticweb.owlapi.util.BidirectionalShortFormProviderAdapter;
 import org.semanticweb.owlapi.util.PropertyAssertionValueShortFormProvider;
 import org.semanticweb.skos.*;
@@ -95,7 +96,7 @@ public class SKOSDatasetImpl implements SKOSDataset {
         if (owlOntology.getOntologyID().getOntologyIRI() == null) {
             return URI.create("http://skosapi.sourceforge.net/anonymous/" + Math.random());
         }
-        return owlOntology.getOntologyID().getOntologyIRI().toURI();
+        return owlOntology.getOntologyID().getOntologyIRI().get().toURI();
     }
 
     public Set<SKOSConceptScheme> getSKOSConceptSchemes() {
@@ -192,7 +193,7 @@ public class SKOSDatasetImpl implements SKOSDataset {
 
     private SKOSEntity entityCreationHandler(OWLNamedIndividual ind) {
 
-        for (OWLClassExpression desc : ind.getTypes(owlOntology)) {
+        for (OWLClassExpression desc : EntitySearcher.getTypes(ind, owlOntology)) {
 
             if (desc instanceof OWLClass) {
 
@@ -392,7 +393,7 @@ public class SKOSDatasetImpl implements SKOSDataset {
 
         AnnotationVisitor annoVis = new AnnotationVisitor(skosManContent);
 
-        for (OWLAnnotation anno : ind.asOWLNamedIndividual().getAnnotations(owlOntology)) {
+        for (OWLAnnotation anno : EntitySearcher.getAnnotations(ind.asOWLNamedIndividual(), owlOntology)) {
 
             OWLAnnotationValue value = anno.getValue();
             value.accept(annoVis);
@@ -509,7 +510,7 @@ public class SKOSDatasetImpl implements SKOSDataset {
         OWLDataPropertyExpression prop2 = man.getOWLDataFactory().getOWLDataProperty(IRI.create(SKOSRDFVocabulary.ALTLABEL.getURI()));
         OWLDataPropertyExpression prop3 = man.getOWLDataFactory().getOWLDataProperty(IRI.create(SKOSRDFVocabulary.HIDDENLABEL.getURI()));
 
-        List<OWLPropertyExpression<?,?>> list = new ArrayList<OWLPropertyExpression<?,?>>();
+        List<OWLPropertyExpression> list = new ArrayList<OWLPropertyExpression>();
         list.add(prop3);
         list.add(prop2);
         list.add(prop1);

--- a/skos-impl/src/main/java/uk/ac/manchester/cs/skos/SKOSObjectPropertyUtility.java
+++ b/skos-impl/src/main/java/uk/ac/manchester/cs/skos/SKOSObjectPropertyUtility.java
@@ -1,6 +1,7 @@
 package uk.ac.manchester.cs.skos;
 
 import org.semanticweb.owlapi.model.*;
+import org.semanticweb.owlapi.search.EntitySearcher;
 
 import java.net.URI;
 import java.util.HashMap;
@@ -69,9 +70,9 @@ public class SKOSObjectPropertyUtility {
 
     private void processProperty(OWLObjectProperty prop, OWLOntology ont) {
 
-        if (!prop.getSuperProperties(ont).isEmpty()) {
+        if (!EntitySearcher.getSuperProperties(prop, ont).isEmpty()) {
             tempProperty.put(prop.getIRI().toURI(), prop);
-            for(OWLObjectPropertyExpression sup : prop.getSuperProperties(ont)) {
+            for(OWLObjectPropertyExpression sup : EntitySearcher.getSuperProperties(prop, ont)) {
                 processProperty(sup.asOWLObjectProperty(), ont);
             }
         }

--- a/skos-impl/src/main/java/uk/ac/manchester/cs/skos/SKOSTypedLiteralImpl.java
+++ b/skos-impl/src/main/java/uk/ac/manchester/cs/skos/SKOSTypedLiteralImpl.java
@@ -45,7 +45,7 @@ public class SKOSTypedLiteralImpl implements SKOSTypedLiteral {
     public SKOSTypedLiteralImpl(OWLDataFactory factory, SKOSDataType dataType, String literal) {
         this.literal = literal;
         this.type = (SKOSDataTypeImpl) dataType;
-        constant = factory.getOWLTypedLiteral(literal, type.getAsOWLDataType());
+        constant = factory.getOWLLiteral(literal, type.getAsOWLDataType());
     }
 
     public String getLiteral() {

--- a/skos-impl/src/main/java/uk/ac/manchester/cs/skos/properties/SKOSAnnotationImpl.java
+++ b/skos-impl/src/main/java/uk/ac/manchester/cs/skos/properties/SKOSAnnotationImpl.java
@@ -1,7 +1,6 @@
 package uk.ac.manchester.cs.skos.properties;
 
 import org.semanticweb.owlapi.model.*;
-import org.semanticweb.owlapi.vocab.OWL2Datatype;
 import org.semanticweb.skos.SKOSAnnotation;
 import org.semanticweb.skos.SKOSEntity;
 import org.semanticweb.skos.SKOSLiteral;


### PR DESCRIPTION
- Modify Maven POM to add a dependency to:
    - com.google.guava
- Fix compilation issues due to changes between v3.x and v4.x of the OWL API (as per https://github.com/owlcs/owlapi/wiki/Migrate-from-version-3.4-and-3.5-to-4.0)
- Increment version number from v3.1 to v3.2